### PR TITLE
feat: add continuous release workflow for master commits

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,0 +1,314 @@
+name: Release Binaries
+
+on:
+  push:
+    branches: [ "master" ]
+  workflow_dispatch:  # Allow manual trigger
+
+env:
+  CARGO_TERM_COLOR: always
+
+permissions:
+  contents: write  # Required for creating releases
+
+jobs:
+  build-linux:
+    name: Build Linux Binaries
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 Linux (static musl)
+      run: |
+        nix build
+        mkdir -p artifacts/linux-x86_64
+        cp result/bin/rmesh artifacts/linux-x86_64/rmesh
+        chmod +x artifacts/linux-x86_64/rmesh
+    
+    - name: Verify static linking
+      run: |
+        file artifacts/linux-x86_64/rmesh | grep "statically linked"
+        ldd artifacts/linux-x86_64/rmesh 2>&1 | grep "not a dynamic executable" || true
+    
+    - name: Create checksums
+      run: |
+        cd artifacts
+        for dir in */; do
+          (cd "$dir" && sha256sum rmesh > rmesh.sha256)
+        done
+    
+    - name: Create tarball archives
+      run: |
+        cd artifacts
+        for dir in */; do
+          dirname="${dir%/}"
+          tar czf "rmesh-${dirname}.tar.gz" "$dirname"
+        done
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: rmesh-linux-binaries
+        path: artifacts/*.tar.gz
+        retention-days: 90
+
+  build-macos:
+    name: Build macOS Binaries
+    runs-on: macos-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-apple-darwin,aarch64-apple-darwin
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 macOS
+      run: |
+        cargo build --release --target x86_64-apple-darwin -p rmesh
+        mkdir -p artifacts/macos-x86_64
+        cp target/x86_64-apple-darwin/release/rmesh artifacts/macos-x86_64/rmesh
+        chmod +x artifacts/macos-x86_64/rmesh
+    
+    - name: Build ARM64 macOS (Apple Silicon)
+      run: |
+        cargo build --release --target aarch64-apple-darwin -p rmesh
+        mkdir -p artifacts/macos-aarch64
+        cp target/aarch64-apple-darwin/release/rmesh artifacts/macos-aarch64/rmesh
+        chmod +x artifacts/macos-aarch64/rmesh
+    
+    - name: Create checksums
+      run: |
+        cd artifacts
+        for dir in */; do
+          (cd "$dir" && shasum -a 256 rmesh > rmesh.sha256)
+        done
+    
+    - name: Create tarball archives
+      run: |
+        cd artifacts
+        for dir in */; do
+          dirname="${dir%/}"
+          tar czf "rmesh-${dirname}.tar.gz" "$dirname"
+        done
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: rmesh-macos-binaries
+        path: artifacts/*.tar.gz
+        retention-days: 90
+
+  build-windows:
+    name: Build Windows Binaries
+    runs-on: windows-latest
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-pc-windows-msvc
+    
+    - name: Cache Cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: cargo-registry-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          cargo-registry-${{ runner.os }}-
+    
+    - name: Build x86_64 Windows
+      run: |
+        cargo build --release --target x86_64-pc-windows-msvc -p rmesh
+        New-Item -ItemType Directory -Force -Path artifacts/windows-x86_64
+        Copy-Item target/x86_64-pc-windows-msvc/release/rmesh.exe artifacts/windows-x86_64/rmesh.exe
+    
+    - name: Create checksums
+      shell: powershell
+      run: |
+        cd artifacts
+        Get-ChildItem -Directory | ForEach-Object {
+          cd $_.Name
+          $hash = Get-FileHash -Algorithm SHA256 rmesh.exe
+          "$($hash.Hash.ToLower())  rmesh.exe" | Out-File -Encoding ASCII rmesh.sha256
+          cd ..
+        }
+    
+    - name: Create ZIP archives
+      shell: powershell
+      run: |
+        cd artifacts
+        Get-ChildItem -Directory | ForEach-Object {
+          Compress-Archive -Path $_.FullName -DestinationPath "rmesh-$($_.Name).zip"
+        }
+    
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: rmesh-windows-binaries
+        path: artifacts/*.zip
+        retention-days: 90
+
+  create-release:
+    name: Create GitHub Release
+    needs: [build-linux, build-macos, build-windows]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    
+    steps:
+    - uses: actions/checkout@v5
+    
+    - name: Download all artifacts
+      uses: actions/download-artifact@v5
+      with:
+        path: release-artifacts
+    
+    - name: Get short SHA
+      id: sha
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+    
+    - name: Get date
+      id: date
+      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+    
+    - name: Prepare release files
+      run: |
+        mkdir -p release-files
+        mv release-artifacts/rmesh-linux-binaries/* release-files/
+        mv release-artifacts/rmesh-macos-binaries/* release-files/
+        mv release-artifacts/rmesh-windows-binaries/* release-files/
+        
+        # Add the bootstrap script
+        cp rmesh.sh release-files/
+        chmod +x release-files/rmesh.sh
+        
+        ls -la release-files/
+    
+    - name: Create release notes
+      run: |
+        cat > release-notes.md << EOF
+        ## rmesh Latest Build (master branch)
+        
+        **Build Date:** $(date +'%Y-%m-%d %H:%M:%S UTC')
+        **Commit:** ${{ steps.sha.outputs.sha_short }}
+        
+        ### Available Binaries
+        
+        #### Linux
+        - \`rmesh-linux-x86_64.tar.gz\` - Static binary (works on all Linux distros)
+        
+        #### macOS
+        - \`rmesh-macos-x86_64.tar.gz\` - Intel Mac binary
+        - \`rmesh-macos-aarch64.tar.gz\` - Apple Silicon (M1/M2/M3) binary
+        
+        #### Windows
+        - \`rmesh-windows-x86_64.zip\` - Windows 64-bit executable
+        
+        ### Installation
+        
+        #### Quick Install (Using Bootstrap Script)
+        
+        Download and use \`rmesh.sh\` for automatic installation and updates:
+        
+        \`\`\`bash
+        curl -L https://github.com/douglaz/rmesh/releases/download/latest-master/rmesh.sh -o rmesh.sh
+        chmod +x rmesh.sh
+        ./rmesh.sh --help
+        \`\`\`
+        
+        The bootstrap script will:
+        - Automatically detect your platform
+        - Download the appropriate binary
+        - Extract and install to \`~/.local/bin\`
+        - Use local builds when available (for development)
+        - Check for updates once per day
+        
+        #### Manual Installation
+        
+        1. Download the appropriate binary for your platform
+        2. Extract the archive
+        3. Make the binary executable (Linux/macOS): \`chmod +x rmesh\`
+        4. Optionally move to your PATH: \`sudo mv rmesh /usr/local/bin/\`
+        
+        ### Verify Checksums
+        
+        Each archive contains a \`.sha256\` file with the binary's checksum.
+        
+        \`\`\`bash
+        # Linux/macOS
+        sha256sum -c rmesh.sha256
+        
+        # Windows (PowerShell)
+        Get-FileHash rmesh.exe -Algorithm SHA256
+        \`\`\`
+        
+        ### Features
+        
+        - Connect to Meshtastic devices via serial or TCP
+        - Real-time message monitoring
+        - Send text messages and waypoints
+        - Channel management
+        - Device configuration
+        - Node information and statistics
+        - Trace route functionality
+        - JSON output support for scripting
+        
+        ---
+        *This is an automated build from the master branch. For stable releases, see the Releases page.*
+        EOF
+    
+    - name: Delete existing latest release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Delete the release if it exists
+        gh release delete latest-master --yes 2>/dev/null || true
+        
+        # Delete the tag if it exists
+        git push --delete origin latest-master 2>/dev/null || true
+    
+    - name: Create new release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create latest-master \
+          --title "Latest Build (master)" \
+          --notes-file release-notes.md \
+          --prerelease \
+          release-files/*


### PR DESCRIPTION
## Summary
This PR adds a continuous release workflow that builds and publishes binaries for every commit to the master branch, similar to how cyberkrill handles releases.

## Changes
- Added `.github/workflows/release-binaries.yml` workflow that triggers on master commits
- Builds static binaries for Linux, macOS (x86_64/ARM64), and Windows
- Creates/updates a `latest-master` pre-release with the latest binaries
- Includes checksums for all binaries
- Includes the rmesh.sh bootstrap script in releases
- 90-day retention for build artifacts

## Benefits
- Users can always download the latest development builds
- The rmesh.sh script can fetch from `latest-master` release
- Automatic updates for users using the bootstrap script
- Consistent with cyberkrill's release strategy

## Test Plan
- [ ] Workflow syntax is valid
- [ ] Will trigger on merge to master
- [ ] Binaries will be built for all platforms
- [ ] Release will be created/updated automatically