### PR TITLE
fix: properly display region codes in radio info

### DIFF
--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -822,6 +822,32 @@ async fn process_config_response(
                 debug!("Updated display config");
             }
             meshtastic::protobufs::config::PayloadVariant::Lora(lora_config) => {
+                // Convert region enum to human-readable string
+                let region_str = match lora_config.region() {
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Unset => "Unset",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Us => "US",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Eu433 => "EU433",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Eu868 => "EU868",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Cn => "CN",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Jp => "JP",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Anz => "ANZ",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Kr => "KR",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Tw => "TW",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ru => "RU",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::In => "IN",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Nz865 => "NZ865",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Th => "TH",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Lora24 => "LORA24",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ua433 => "UA433",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ua868 => "UA868",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::My433 => "MY433",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::My919 => "MY919",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Sg923 => "SG923",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ph433 => "PH433",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ph868 => "PH868",
+                    meshtastic::protobufs::config::lo_ra_config::RegionCode::Ph915 => "PH915",
+                };
+
                 state.lora_config = Some(LoraConfig {
                     use_preset: lora_config.use_preset,
                     modem_preset: format!("{preset:?}", preset = lora_config.modem_preset()),
@@ -829,7 +855,7 @@ async fn process_config_response(
                     spread_factor: lora_config.spread_factor,
                     coding_rate: lora_config.coding_rate,
                     frequency_offset: lora_config.frequency_offset,
-                    region: format!("{region:?}", region = lora_config.region()),
+                    region: region_str.to_string(),
                     hop_limit: lora_config.hop_limit,
                     tx_enabled: lora_config.tx_enabled,
                     tx_power: lora_config.tx_power,


### PR DESCRIPTION
## Summary
This PR fixes the region display in `rmesh info radio` to show proper region codes instead of 'Unknown'.

## Problem
The region was showing as 'Unknown' because:
1. The region enum was being formatted with Debug format, producing values like 'Unset'
2. All region codes needed proper string conversion

## Solution
- Added explicit match statement to convert all 22 Meshtastic region codes to human-readable strings
- Handles all regions: US, EU433, EU868, CN, JP, ANZ, KR, TW, RU, IN, NZ865, TH, LORA24, UA433, UA868, MY433, MY919, SG923, PH433, PH868, PH915
- Shows 'Unset' when region is not configured (instead of 'Unknown')

## Note
There's a separate issue where the LoRa config might not be automatically requested from the device on connection. This fix handles the display when the config is available. A follow-up PR may be needed to ensure LoRa config is always requested during initialization.

## Test Plan
- [ ] Build passes
- [ ] When LoRa config is available, region displays correctly
- [ ] All 22 region codes are handled