### PR TITLE
feat: automatically request device configuration on connection

### DIFF
--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result, bail, ensure};
-use meshtastic::Message as ProstMessage;
+use meshtastic::Message;
 use meshtastic::api::state::Configured;
 use meshtastic::api::{ConnectedStreamApi, StreamApi};
 use meshtastic::packet::{PacketReceiver, PacketRouter};
@@ -147,6 +147,12 @@ impl ConnectionManager {
 
         // Start packet processing
         self.start_packet_processing(packet_receiver).await;
+
+        // Request all configuration from the device
+        if let Err(e) = self.request_all_configs().await {
+            warn!("Failed to request device configuration: {e}");
+            // Continue anyway as this is not critical for connection
+        }
 
         info!("Connection established and configured successfully");
         Ok(())
@@ -304,6 +310,66 @@ impl ConnectionManager {
                 Ok(Vec::new())
             }
         }
+    }
+
+    /// Request all configuration from the device
+    async fn request_all_configs(&mut self) -> Result<()> {
+        info!("Requesting device configuration...");
+
+        let api = self.get_api()?;
+
+        // List of config types to request
+        let config_types = [
+            meshtastic::protobufs::admin_message::ConfigType::DeviceConfig,
+            meshtastic::protobufs::admin_message::ConfigType::PositionConfig,
+            meshtastic::protobufs::admin_message::ConfigType::PowerConfig,
+            meshtastic::protobufs::admin_message::ConfigType::NetworkConfig,
+            meshtastic::protobufs::admin_message::ConfigType::DisplayConfig,
+            meshtastic::protobufs::admin_message::ConfigType::LoraConfig,
+            meshtastic::protobufs::admin_message::ConfigType::BluetoothConfig,
+        ];
+
+        for config_type in config_types {
+            debug!("Requesting config type: {config_type:?}");
+
+            // Create admin message for config request
+            let admin_msg = meshtastic::protobufs::AdminMessage {
+                payload_variant: Some(
+                    meshtastic::protobufs::admin_message::PayloadVariant::GetConfigRequest(
+                        config_type as i32,
+                    ),
+                ),
+                session_passkey: Vec::new(),
+            };
+
+            // Create mesh packet
+            let mesh_packet = meshtastic::protobufs::MeshPacket {
+                payload_variant: Some(meshtastic::protobufs::mesh_packet::PayloadVariant::Decoded(
+                    meshtastic::protobufs::Data {
+                        portnum: meshtastic::protobufs::PortNum::AdminApp as i32,
+                        payload: admin_msg.encode_to_vec(),
+                        ..Default::default()
+                    },
+                )),
+                to: 0, // Local destination
+                ..Default::default()
+            };
+
+            // Send config request
+            api.send_to_radio_packet(Some(
+                meshtastic::protobufs::to_radio::PayloadVariant::Packet(mesh_packet),
+            ))
+            .await?;
+
+            // Small delay between requests to avoid overwhelming the device
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        // Give time for all config responses to be received and processed
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
+        info!("Configuration requests sent");
+        Ok(())
     }
 
     pub async fn send_text_with_ack(
@@ -599,13 +665,20 @@ async fn process_mesh_packet(
         }
 
         meshtastic::protobufs::PortNum::AdminApp => {
+            debug!("Received AdminApp packet");
             if let Ok(admin_msg) =
                 meshtastic::protobufs::AdminMessage::decode(packet_data.payload.as_slice())
-                && let Some(
+            {
+                debug!("Decoded admin message: {admin_msg:?}");
+                if let Some(
                     meshtastic::protobufs::admin_message::PayloadVariant::GetConfigResponse(config),
                 ) = admin_msg.payload_variant
-            {
-                process_config_response(config, device_state).await?;
+                {
+                    debug!("Processing config response");
+                    process_config_response(config, device_state).await?;
+                }
+            } else {
+                debug!("Failed to decode admin message");
             }
         }
 

--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -505,6 +505,15 @@ async fn process_from_radio_packet(
             process_mesh_packet(mesh_packet, device_state, ack_waiters, route_waiters).await?;
         }
 
+        meshtastic::protobufs::from_radio::PayloadVariant::Config(config) => {
+            debug!("Received Config packet during initial connection");
+            process_config_response(config, device_state).await?;
+        }
+
+        meshtastic::protobufs::from_radio::PayloadVariant::ConfigCompleteId(id) => {
+            info!("Config complete received with ID: {id}");
+        }
+
         variant => {
             // Other packet types not yet handled
             debug!("Unhandled FromRadio packet variant: {variant:?}");

--- a/test-rmesh.sh
+++ b/test-rmesh.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Wrapper script to test rmesh without freezing terminal
+
+# Parse arguments
+RMESH_ARGS="$@"
+OUTPUT_FILE="/tmp/rmesh-test-$$.log"
+PID_FILE="/tmp/rmesh-test-$$.pid"
+
+# Function to cleanup on exit
+cleanup() {
+    if [ -f "$PID_FILE" ]; then
+        PID=$(cat "$PID_FILE")
+        if kill -0 "$PID" 2>/dev/null; then
+            echo "Stopping rmesh process (PID: $PID)..."
+            kill "$PID" 2>/dev/null
+        fi
+        rm -f "$PID_FILE"
+    fi
+    rm -f "$OUTPUT_FILE"
+}
+
+# Set trap for cleanup
+trap cleanup EXIT INT TERM
+
+# Start rmesh in background with nohup
+echo "Starting rmesh with args: $RMESH_ARGS"
+echo "Output file: $OUTPUT_FILE"
+nohup cargo run --bin rmesh -- $RMESH_ARGS > "$OUTPUT_FILE" 2>&1 &
+RMESH_PID=$!
+echo $RMESH_PID > "$PID_FILE"
+
+echo "rmesh started with PID: $RMESH_PID"
+echo "Watching output (press Ctrl+C to stop)..."
+echo "---"
+
+# Give it a moment to start
+sleep 0.5
+
+# Tail the output file
+tail -f "$OUTPUT_FILE" &
+TAIL_PID=$!
+
+# Wait for a specific duration or until interrupted
+if [[ "$1" == "--timeout" ]]; then
+    TIMEOUT="$2"
+    shift 2
+    sleep "$TIMEOUT"
+    echo "Timeout reached, stopping..."
+else
+    # Wait for user interrupt
+    wait $TAIL_PID
+fi
+
+# Kill tail if still running
+kill $TAIL_PID 2>/dev/null
+
+# The trap will handle cleanup


### PR DESCRIPTION
## Summary
- Automatically request device configuration when connecting
- Fix region display showing as 'Unknown' by properly handling Config packets

## Changes
1. **Added automatic config requests on connection**
   - Requests all configuration types (Device, LoRa, Position, Power, Network, Display, Bluetooth)
   - Non-blocking - connection continues even if requests fail
   - Adds small delays between requests to avoid overwhelming device

2. **Fixed region display issue**
   - Previously, Config packets from device were being ignored
   - Now properly handles `Config` and `ConfigCompleteId` variants from `FromRadio` enum
   - Region (e.g., "ANZ", "US", "EU868") now displays correctly in `rmesh info radio`

## Test Results
Before fix:
```json
{
  "region": "Unknown",
  ...
}
```

After fix:
```json
{
  "region": "ANZ",
  ...
}
```

## Notes
- The device sends Config packets during initial connection handshake
- These packets contain LoRa configuration including the region code
- Admin authentication may be required for manual config requests (future enhancement)
- Created `test-rmesh.sh` wrapper script for testing without terminal freezing

## Breaking Changes
None - this fix only improves existing functionality