### PR TITLE
feat: improve serial communication and fix region display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 [[package]]
 name = "meshtastic"
 version = "0.1.7"
-source = "git+https://github.com/meshtastic/rust.git?branch=main#d0421b5fea6038bbacb0cdfc1ac51e7b25df26f3"
+source = "git+https://github.com/douglaz/meshtastic-rust.git?branch=fix-serial-logging#9cf2d3d4266864edc0b9e750aa34cdf0a2a64a2b"
 dependencies = [
  "bluez-async",
  "btleplug",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/yourusername/rmesh"
 
 [workspace.dependencies]
 # Core dependencies
-meshtastic = { git = "https://github.com/meshtastic/rust.git", branch = "main", features = ["serde"] }
+meshtastic = { git = "https://github.com/douglaz/meshtastic-rust.git", branch = "fix-serial-logging", features = ["serde"] }
 tokio = { version = "1.43", features = ["full"] }
 anyhow = "1.0"
 thiserror = "2.0"

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
             outputHashes = {
-              "meshtastic-0.1.7" = "sha256-OPccMaD8A7IzQjgiOgrTUXKWESHEWkp9Zdo3+xetMM4=";
+              "meshtastic-0.1.7" = "sha256-yKUDnKCOb+yM272K4SrRvuM/sstAngr4ZJaTyLcU2pk=";
             };
           };
           
@@ -120,7 +120,7 @@
           cargoLock = {
             lockFile = ./Cargo.lock;
             outputHashes = {
-              "meshtastic-0.1.7" = "sha256-OPccMaD8A7IzQjgiOgrTUXKWESHEWkp9Zdo3+xetMM4=";
+              "meshtastic-0.1.7" = "sha256-yKUDnKCOb+yM272K4SrRvuM/sstAngr4ZJaTyLcU2pk=";
             };
           };
           

--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -114,8 +114,12 @@ impl ConnectionManager {
                 // This helps the device wake up and resync its serial state machine
                 use tokio::io::AsyncWriteExt;
                 let wake_sequence = vec![0xc3; 32]; // START2 byte repeated
-                stream.stream.write_all(&wake_sequence).await.ok();
-                stream.stream.flush().await.ok();
+                if let Err(e) = stream.stream.write_all(&wake_sequence).await {
+                    debug!("Failed to send wake sequence: {e}");
+                }
+                if let Err(e) = stream.stream.flush().await {
+                    debug!("Failed to flush wake sequence: {e}");
+                }
 
                 // Add a brief delay for serial port stabilization
                 // This helps avoid initial sync errors with stale data
@@ -148,8 +152,12 @@ impl ConnectionManager {
             // This helps the device wake up and resync its serial state machine
             use tokio::io::AsyncWriteExt;
             let wake_sequence = vec![0xc3; 32]; // START2 byte repeated
-            stream.stream.write_all(&wake_sequence).await.ok();
-            stream.stream.flush().await.ok();
+            if let Err(e) = stream.stream.write_all(&wake_sequence).await {
+                debug!("Failed to send wake sequence: {e}");
+            }
+            if let Err(e) = stream.stream.flush().await {
+                debug!("Failed to flush wake sequence: {e}");
+            }
 
             // Add a brief delay for serial port stabilization
             // This helps avoid initial sync errors with stale data

--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -102,13 +102,20 @@ impl ConnectionManager {
             } else {
                 // Serial connection
                 info!("Connecting via serial port {port}");
-                let stream = utils::stream::build_serial_stream(
+                let mut stream = utils::stream::build_serial_stream(
                     port.clone(),
                     None, // Use default baud rate
                     None, // Use default DTR
                     None, // Use default RTS
                 )
                 .context("Failed to connect via serial")?;
+
+                // Send wake sequence to force device resync (similar to Python implementation)
+                // This helps the device wake up and resync its serial state machine
+                use tokio::io::AsyncWriteExt;
+                let wake_sequence = vec![0xc3; 32]; // START2 byte repeated
+                stream.stream.write_all(&wake_sequence).await.ok();
+                stream.stream.flush().await.ok();
 
                 // Add a brief delay for serial port stabilization
                 // This helps avoid initial sync errors with stale data
@@ -130,12 +137,19 @@ impl ConnectionManager {
             let port_name = ports[0].clone();
             info!("Using auto-detected port: {port_name}");
 
-            let stream = utils::stream::build_serial_stream(
+            let mut stream = utils::stream::build_serial_stream(
                 port_name, None, // Use default baud rate
                 None, // Use default DTR
                 None, // Use default RTS
             )
             .context("Failed to connect to auto-detected serial port")?;
+
+            // Send wake sequence to force device resync (similar to Python implementation)
+            // This helps the device wake up and resync its serial state machine
+            use tokio::io::AsyncWriteExt;
+            let wake_sequence = vec![0xc3; 32]; // START2 byte repeated
+            stream.stream.write_all(&wake_sequence).await.ok();
+            stream.stream.flush().await.ok();
 
             // Add a brief delay for serial port stabilization
             // This helps avoid initial sync errors with stale data

--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -109,6 +109,11 @@ impl ConnectionManager {
                     None, // Use default RTS
                 )
                 .context("Failed to connect via serial")?;
+
+                // Add a brief delay for serial port stabilization
+                // This helps avoid initial sync errors with stale data
+                tokio::time::sleep(Duration::from_millis(100)).await;
+
                 stream_api.connect(stream).await
             }
         } else {
@@ -131,6 +136,11 @@ impl ConnectionManager {
                 None, // Use default RTS
             )
             .context("Failed to connect to auto-detected serial port")?;
+
+            // Add a brief delay for serial port stabilization
+            // This helps avoid initial sync errors with stale data
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
             stream_api.connect(stream).await
         };
 
@@ -186,6 +196,8 @@ impl ConnectionManager {
         self.packet_processor = Some(handle);
 
         // Give the processor a moment to start receiving initial packets
+        // This also serves as a connection stabilization period where initial
+        // sync errors are expected and can be safely ignored
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 


### PR DESCRIPTION
## Summary
- Fix region display showing as "Unknown" 
- Improve serial communication stability
- Eliminate serial sync error spam

## Changes

### 1. Fixed Region Display
- Added handler for `Config` packets from device during initial connection
- Added handler for `ConfigCompleteId` to track config completion
- Region (e.g., "ANZ", "US", "EU868") now displays correctly in `rmesh info radio`

### 2. Improved Serial Communication
- Added wake sequence (32 bytes of 0xc3) on serial connection to force device resync
- Added 100ms stabilization delay after opening serial port
- Matches Python implementation behavior for serial initialization

### 3. Clean Serial Output
- Using forked meshtastic-rust with reduced error verbosity
- Serial sync messages changed from ERROR to TRACE/DEBUG level
- Non-packet bytes are now treated as debug/log output from device (not errors)

## Results

### Before:
```
[ERROR] Could not find header sequence [0x94, 0xc3], purging buffer...
[ERROR] Could not find header sequence [0x94, 0xc3], purging buffer...
... (hundreds of error messages)
{
  "region": "Unknown",
  ...
}
```

### After:
```
{
  "region": "ANZ",
  ...
}
```
(Clean output, no error spam)

## Dependencies
- Uses forked meshtastic-rust (https://github.com/douglaz/meshtastic-rust.git branch: fix-serial-logging)
- Fork includes logging improvements to reduce verbosity

## Testing
- Tested with Meshtastic TrackerT1000E device
- Region displays correctly
- No serial sync errors in output
- Connection is stable and reliable

## Breaking Changes
None - all changes are improvements to existing functionality