### PR TITLE
fix: ensure JSON output is always valid for empty data

### DIFF
--- a/rmesh/src/commands/info.rs
+++ b/rmesh/src/commands/info.rs
@@ -115,14 +115,16 @@ pub async fn handle_info(
             // Use the core library function
             let nodes = rmesh_core::mesh::get_nodes(&connection).await?;
 
-            if nodes.is_empty() {
-                println!("No nodes found in the mesh network");
-                return Ok(());
-            }
-
             match format {
-                OutputFormat::Json => print_output(&nodes, format),
+                OutputFormat::Json => {
+                    // Always output JSON, even if empty (will be [])
+                    print_output(&nodes, format);
+                }
                 OutputFormat::Table => {
+                    if nodes.is_empty() {
+                        println!("No nodes found in the mesh network");
+                        return Ok(());
+                    }
                     let mut table = create_table();
                     table.set_header(vec![
                         Cell::new("ID"),
@@ -197,14 +199,17 @@ pub async fn handle_info(
             // Get position data from device state
             let state = connection.get_device_state().await;
 
-            if state.positions.is_empty() {
-                println!("No position data available");
-                return Ok(());
-            }
-
             match format {
-                OutputFormat::Json => print_output(&state.positions, format),
+                OutputFormat::Json => {
+                    // Always output JSON, even if empty (will be {})
+                    print_output(&state.positions, format);
+                }
                 OutputFormat::Table => {
+                    if state.positions.is_empty() {
+                        println!("No position data available");
+                        return Ok(());
+                    }
+
                     let mut table = create_table();
                     table.set_header(vec![
                         Cell::new("Node ID"),
@@ -238,14 +243,16 @@ pub async fn handle_info(
             // Get telemetry data from device state
             let state = connection.get_device_state().await;
 
-            if state.telemetry.is_empty() {
-                println!("No telemetry data available");
-                return Ok(());
-            }
-
             match format {
-                OutputFormat::Json => print_output(&state.telemetry, format),
+                OutputFormat::Json => {
+                    // Always output JSON, even if empty (will be {})
+                    print_output(&state.telemetry, format);
+                }
                 OutputFormat::Table => {
+                    if state.telemetry.is_empty() {
+                        println!("No telemetry data available");
+                        return Ok(());
+                    }
                     let mut table = create_table();
                     table.set_header(vec![
                         Cell::new("Node ID"),


### PR DESCRIPTION
## Summary
This PR fixes two related issues with JSON output:
1. Info commands would output plain text messages instead of valid JSON when data was empty, causing `jq` parsing errors
2. Nix shell hook and git hooks were outputting to stdout, contaminating JSON output when piping

## Problems

### Problem 1: Invalid JSON for empty data
When running commands like `rmesh info position --json | jq`, if no data was available, the command would output plain text like "No position data available" instead of valid JSON, resulting in:
```
jq: parse error: Invalid numeric literal at line 1, column 5
```

### Problem 2: Nix banner contaminating stdout
The Nix development environment banner was being output to stdout, breaking JSON parsing:
```bash
$ nix develop -c cargo run --bin rmesh info position --json | jq
🔧 rmesh Development Environment
...
jq: parse error: Invalid numeric literal at line 1, column 5
```

## Solutions

### Solution 1: Always output valid JSON
Modified the info commands to always output valid JSON when `--json` format is specified:
- Empty positions now output as `{}` (empty object)
- Empty nodes now output as `[]` (empty array)  
- Empty telemetry now output as `{}` (empty object)

Plain text messages are only shown in table format mode.

### Solution 2: Redirect informational output to stderr
All echo statements in:
- `flake.nix` shellHook
- `.githooks/pre-commit`
- `.githooks/pre-push`

Now redirect to stderr (`>&2`) so they don't contaminate stdout when piping.

## Changes
- Restructured the `info position`, `info nodes`, and `info telemetry` commands to check output format first
- JSON format always outputs the data structure, even if empty
- Table format continues to show user-friendly messages when no data is available
- All informational echo statements redirect to stderr to keep stdout clean for data output

## Testing
```bash
# Before fixes:
$ nix develop -c cargo run --bin rmesh info position --json | jq
jq: parse error: Invalid numeric literal at line 1, column 5

# After fixes:
$ nix develop -c cargo run --bin rmesh info position --json | jq
{}

# With data:
$ nix develop -c cargo run --bin rmesh info nodes --json | jq '. | length'
8

# Nix banner now goes to stderr, not contaminating stdout
$ nix develop -c cargo run --bin rmesh info position --json 2>/dev/null | jq
{}
```

## Breaking Changes
None - these are bug fixes that make the JSON output behave as expected.