### PR TITLE
fix: redirect all output to stderr in nix shell and git hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,21 +5,21 @@ set -euo pipefail
 if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
     # Use nix develop for consistent environment
     if ! nix develop -c cargo fmt --check 2>/dev/null; then
-        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before committing."
-        echo ""
-        echo "To see what needs formatting:"
-        echo "  nix develop -c cargo fmt --check --verbose"
+        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before committing." >&2
+        echo "" >&2
+        echo "To see what needs formatting:" >&2
+        echo "  nix develop -c cargo fmt --check --verbose" >&2
         exit 1
     fi
 else
     # Fallback to regular cargo
     if ! cargo fmt --check 2>/dev/null; then
-        echo "❌ Code is not formatted. Please run 'cargo fmt' before committing."
-        echo ""
-        echo "To see what needs formatting:"
-        echo "  cargo fmt --check --verbose"
+        echo "❌ Code is not formatted. Please run 'cargo fmt' before committing." >&2
+        echo "" >&2
+        echo "To see what needs formatting:" >&2
+        echo "  cargo fmt --check --verbose" >&2
         exit 1
     fi
 fi
 
-echo "✅ Code formatting check passed"
+echo "✅ Code formatting check passed" >&2

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,133 +1,133 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "🔍 Running pre-push checks..."
-echo ""
+echo "🔍 Running pre-push checks..." >&2
+echo "" >&2
 
 # Check if we're in a nix environment
 if command -v nix >/dev/null 2>&1 && [ -f "flake.nix" ]; then
     # Check formatting
-    echo "📝 Checking code formatting..."
+    echo "📝 Checking code formatting..." >&2
     if ! nix develop -c cargo fmt --check 2>/dev/null; then
-        echo ""
-        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before pushing."
-        echo ""
-        echo "To see what needs formatting:"
-        echo "  nix develop -c cargo fmt --check --verbose"
+        echo "" >&2
+        echo "❌ Code is not formatted. Please run 'nix develop -c cargo fmt' before pushing." >&2
+        echo "" >&2
+        echo "To see what needs formatting:" >&2
+        echo "  nix develop -c cargo fmt --check --verbose" >&2
         exit 1
     fi
-    echo "✅ Formatting check passed"
-    echo ""
+    echo "✅ Formatting check passed" >&2
+    echo "" >&2
     
     # Run clippy (without --all-features since Bluetooth requires dbus)
-    echo "🔎 Running clippy linting..."
+    echo "🔎 Running clippy linting..." >&2
     if ! nix develop -c cargo clippy --all-targets -- -D warnings 2>&1; then
-        echo ""
-        echo "❌ Clippy found issues. Please fix them before pushing."
-        echo ""
-        echo "To see all issues:"
-        echo "  nix develop -c cargo clippy --all-targets"
-        echo ""
-        echo "To attempt automatic fixes:"
-        echo "  nix develop -c cargo clippy --all-targets --fix --allow-dirty"
+        echo "" >&2
+        echo "❌ Clippy found issues. Please fix them before pushing." >&2
+        echo "" >&2
+        echo "To see all issues:" >&2
+        echo "  nix develop -c cargo clippy --all-targets" >&2
+        echo "" >&2
+        echo "To attempt automatic fixes:" >&2
+        echo "  nix develop -c cargo clippy --all-targets --fix --allow-dirty" >&2
         exit 1
     fi
-    echo "✅ Clippy check passed"
-    echo ""
+    echo "✅ Clippy check passed" >&2
+    echo "" >&2
     
     # Run tests
-    echo "🧪 Running tests..."
+    echo "🧪 Running tests..." >&2
     if ! nix develop -c cargo test --all 2>&1; then
-        echo ""
-        echo "❌ Tests failed. Please fix them before pushing."
-        echo ""
-        echo "To run tests with output:"
-        echo "  nix develop -c cargo test --all -- --nocapture"
+        echo "" >&2
+        echo "❌ Tests failed. Please fix them before pushing." >&2
+        echo "" >&2
+        echo "To run tests with output:" >&2
+        echo "  nix develop -c cargo test --all -- --nocapture" >&2
         exit 1
     fi
-    echo "✅ All tests passed"
-    echo ""
+    echo "✅ All tests passed" >&2
+    echo "" >&2
     
     # Check for outdated dependencies (warning only)
-    echo "📦 Checking for outdated dependencies..."
+    echo "📦 Checking for outdated dependencies..." >&2
     if ! nix develop -c cargo outdated --exit-code 1 --root-deps-only 2>/dev/null; then
-        echo ""
-        echo "⚠️  Warning: Outdated dependencies detected:"
+        echo "" >&2
+        echo "⚠️  Warning: Outdated dependencies detected:" >&2
         nix develop -c cargo outdated --root-deps-only 2>/dev/null | head -30
-        echo ""
-        echo "To update compatible versions:"
-        echo "  nix develop -c cargo upgrade"
-        echo ""
-        echo "For incompatible updates (major versions), review changelog and update manually."
-        echo "Consider updating dependencies when appropriate."
+        echo "" >&2
+        echo "To update compatible versions:" >&2
+        echo "  nix develop -c cargo upgrade" >&2
+        echo "" >&2
+        echo "For incompatible updates (major versions), review changelog and update manually." >&2
+        echo "Consider updating dependencies when appropriate." >&2
     else
-        echo "✅ All dependencies are up to date"
+        echo "✅ All dependencies are up to date" >&2
     fi
 else
     # Fallback to regular cargo
-    echo "📝 Checking code formatting..."
+    echo "📝 Checking code formatting..." >&2
     if ! cargo fmt --check 2>/dev/null; then
-        echo ""
-        echo "❌ Code is not formatted. Please run 'cargo fmt' before pushing."
-        echo ""
-        echo "To see what needs formatting:"
-        echo "  cargo fmt --check --verbose"
+        echo "" >&2
+        echo "❌ Code is not formatted. Please run 'cargo fmt' before pushing." >&2
+        echo "" >&2
+        echo "To see what needs formatting:" >&2
+        echo "  cargo fmt --check --verbose" >&2
         exit 1
     fi
-    echo "✅ Formatting check passed"
-    echo ""
+    echo "✅ Formatting check passed" >&2
+    echo "" >&2
     
     # Run clippy
-    echo "🔎 Running clippy linting..."
+    echo "🔎 Running clippy linting..." >&2
     if ! cargo clippy --all-targets -- -D warnings 2>&1; then
-        echo ""
-        echo "❌ Clippy found issues. Please fix them before pushing."
-        echo ""
-        echo "To see all issues:"
-        echo "  cargo clippy --all-targets"
-        echo ""
-        echo "To attempt automatic fixes:"
-        echo "  cargo clippy --all-targets --fix --allow-dirty"
+        echo "" >&2
+        echo "❌ Clippy found issues. Please fix them before pushing." >&2
+        echo "" >&2
+        echo "To see all issues:" >&2
+        echo "  cargo clippy --all-targets" >&2
+        echo "" >&2
+        echo "To attempt automatic fixes:" >&2
+        echo "  cargo clippy --all-targets --fix --allow-dirty" >&2
         exit 1
     fi
-    echo "✅ Clippy check passed"
-    echo ""
+    echo "✅ Clippy check passed" >&2
+    echo "" >&2
     
     # Run tests
-    echo "🧪 Running tests..."
+    echo "🧪 Running tests..." >&2
     if ! cargo test --all 2>&1; then
-        echo ""
-        echo "❌ Tests failed. Please fix them before pushing."
-        echo ""
-        echo "To run tests with output:"
-        echo "  cargo test --all -- --nocapture"
+        echo "" >&2
+        echo "❌ Tests failed. Please fix them before pushing." >&2
+        echo "" >&2
+        echo "To run tests with output:" >&2
+        echo "  cargo test --all -- --nocapture" >&2
         exit 1
     fi
-    echo "✅ All tests passed"
-    echo ""
+    echo "✅ All tests passed" >&2
+    echo "" >&2
     
     # Check for outdated dependencies (non-nix fallback, warning only)
-    echo "📦 Checking for outdated dependencies..."
+    echo "📦 Checking for outdated dependencies..." >&2
     if command -v cargo-outdated >/dev/null 2>&1; then
         if ! cargo outdated --exit-code 1 --root-deps-only 2>/dev/null; then
-            echo ""
-            echo "⚠️  Warning: Outdated dependencies detected:"
+            echo "" >&2
+            echo "⚠️  Warning: Outdated dependencies detected:" >&2
             cargo outdated --root-deps-only 2>/dev/null | head -30
-            echo ""
-            echo "To update compatible versions:"
-            echo "  cargo upgrade"
-            echo ""
-            echo "For incompatible updates (major versions), review changelog and update manually."
-            echo "Consider updating dependencies when appropriate."
+            echo "" >&2
+            echo "To update compatible versions:" >&2
+            echo "  cargo upgrade" >&2
+            echo "" >&2
+            echo "For incompatible updates (major versions), review changelog and update manually." >&2
+            echo "Consider updating dependencies when appropriate." >&2
         else
-            echo "✅ All dependencies are up to date"
+            echo "✅ All dependencies are up to date" >&2
         fi
     else
-        echo "⚠️  cargo-outdated not found. Skipping dependency check."
-        echo "   Install with: cargo install cargo-outdated"
+        echo "⚠️  cargo-outdated not found. Skipping dependency check." >&2
+        echo "   Install with: cargo install cargo-outdated" >&2
     fi
 fi
 
-echo ""
-echo "✅ All pre-push checks passed! Proceeding with push..."
-echo ""
+echo "" >&2
+echo "✅ All pre-push checks passed! Proceeding with push..." >&2
+echo "" >&2

--- a/flake.nix
+++ b/flake.nix
@@ -175,40 +175,40 @@
           PKG_CONFIG_PATH = "${pkgs.pkgsStatic.openssl.dev}/lib/pkgconfig:${pkgs.dbus.dev}/lib/pkgconfig";
           
           shellHook = ''
-            echo "🔧 rmesh Development Environment"
-            echo ""
+            echo "🔧 rmesh Development Environment" >&2
+            echo "" >&2
             
             # Automatically configure Git hooks for code quality
             if [ -d .git ] && [ -d .githooks ]; then
               current_hooks_path=$(git config core.hooksPath || echo "")
               if [ "$current_hooks_path" != ".githooks" ]; then
-                echo "📎 Setting up Git hooks for code quality checks..."
+                echo "📎 Setting up Git hooks for code quality checks..." >&2
                 git config core.hooksPath .githooks
-                echo "✅ Git hooks configured automatically!"
-                echo "   • pre-commit: Checks code formatting"
-                echo "   • pre-push: Runs formatting, clippy, and tests"
-                echo ""
-                echo "To disable: git config --unset core.hooksPath"
-                echo ""
+                echo "✅ Git hooks configured automatically!" >&2
+                echo "   • pre-commit: Checks code formatting" >&2
+                echo "   • pre-push: Runs formatting, clippy, and tests" >&2
+                echo "" >&2
+                echo "To disable: git config --unset core.hooksPath" >&2
+                echo "" >&2
               fi
             fi
             
-            echo "Available commands:"
-            echo "  cargo build                - Build debug version"
-            echo "  cargo build --release      - Build optimized version"
-            echo "  cargo run -- --help        - Run CLI with help"
-            echo "  cargo test                 - Run tests"
-            echo "  cargo clippy               - Run linter"
-            echo "  cargo fmt                  - Format code"
-            echo "  cargo outdated             - Check for outdated dependencies"
-            echo ""
-            echo "Build static binary:"
-            echo "  cargo build --release --target x86_64-unknown-linux-musl"
-            echo ""
-            echo "Git hooks:"
-            echo "  • pre-commit: Ensures code is formatted"
-            echo "  • pre-push: Runs full quality checks (fmt, clippy, tests)"
-            echo ""
+            echo "Available commands:" >&2
+            echo "  cargo build                - Build debug version" >&2
+            echo "  cargo build --release      - Build optimized version" >&2
+            echo "  cargo run -- --help        - Run CLI with help" >&2
+            echo "  cargo test                 - Run tests" >&2
+            echo "  cargo clippy               - Run linter" >&2
+            echo "  cargo fmt                  - Format code" >&2
+            echo "  cargo outdated             - Check for outdated dependencies" >&2
+            echo "" >&2
+            echo "Build static binary:" >&2
+            echo "  cargo build --release --target x86_64-unknown-linux-musl" >&2
+            echo "" >&2
+            echo "Git hooks:" >&2
+            echo "  • pre-commit: Ensures code is formatted" >&2
+            echo "  • pre-push: Runs full quality checks (fmt, clippy, tests)" >&2
+            echo "" >&2
           '';
         };
       }


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Nix development environment banner and git hook messages were being output to stdout, contaminating JSON output when piping commands.

## Problem
When running commands like:
```bash
nix develop -c cargo run --bin rmesh info position --json | jq
```

The Nix development environment banner was being output to stdout, breaking JSON parsing:
```
🔧 rmesh Development Environment

Available commands:
  cargo build                - Build debug version
  ...
```

This would cause `jq` to fail with parse errors because the JSON was mixed with plain text.

## Solution
All echo statements in the Nix shell hook and git hooks now redirect to stderr (`>&2`) instead of stdout.

## Changes
- **flake.nix**: All shellHook echo statements redirect to stderr
- **.githooks/pre-commit**: All echo statements redirect to stderr  
- **.githooks/pre-push**: All echo statements redirect to stderr

## Testing
```bash
# Before: Banner goes to stdout, breaks jq
$ nix develop -c cargo run --bin rmesh info position --json | jq
parse error: Invalid numeric literal at line 1, column 5

# After: Banner goes to stderr, jq works perfectly
$ nix develop -c cargo run --bin rmesh info position --json | jq
{}

# Banner still visible to user (via stderr), but doesn't contaminate data
$ nix develop -c cargo run --bin rmesh info position --json 2>/dev/null | jq
{}
```

## Impact
- Informational messages are still shown to users via stderr
- stdout is now clean for data output only
- Piping to tools like `jq`, `grep`, etc. now works reliably
- No breaking changes - this only affects where output is directed

This complements PR #9 which fixed the JSON output format for empty data.