### PR TITLE
feat: improve position data collection with --wait and --request-all flags

### DIFF
--- a/rmesh/src/cli.rs
+++ b/rmesh/src/cli.rs
@@ -107,7 +107,15 @@ pub enum InfoCommands {
     /// Display node list
     Nodes,
     /// Display position information
-    Position,
+    Position {
+        /// Wait for position broadcasts (in seconds)
+        #[arg(short = 'w', long)]
+        wait: Option<u64>,
+
+        /// Request positions from all known nodes
+        #[arg(short = 'r', long = "request-all")]
+        request_all: bool,
+    },
     /// Display device metrics
     Metrics,
     /// Display telemetry data


### PR DESCRIPTION
## Summary
- Adds `--wait` flag to collect position broadcasts for a specified duration
- Adds `--request-all` flag to actively request positions from all known nodes
- Fixes the issue where position data only appeared during brief connection window

## Problem
Previously, the `rmesh info position` command would only show position data that happened to arrive during the ~1-2 second connection window. This made it very unreliable to get position information, as observed when position data would appear once and then disappear on subsequent runs.

## Solution
This PR introduces two new flags to make position data collection more reliable:

1. **`--wait <seconds>`**: Keeps the connection open and collects position broadcasts for the specified duration
2. **`--request-all`**: Actively requests positions from all known nodes and waits for responses

## Implementation Details
- Added `collect_positions()` function that polls device state for position updates during the wait period
- Added `request_all_positions()` function that sends position requests to all nodes with `wantResponse=true`
- Modified the CLI to accept the new flags
- Updated the info command handler to use the new collection methods

## Usage Examples
```bash
# Wait 30 seconds for position broadcasts
rmesh info position --wait 30

# Request positions from all known nodes
rmesh info position --request-all

# Combine with JSON output
rmesh info position --wait 10 --json
```

## Test Plan
- [x] Tested `--wait` flag with various durations
- [x] Tested `--request-all` flag successfully retrieves positions
- [x] Verified JSON output works with both flags
- [x] Confirmed original behavior unchanged when no flags used
- [x] All existing tests pass