### PR TITLE
fix: allow --wait and --request-all flags to work together

### DIFF
--- a/rmesh/src/commands/info.rs
+++ b/rmesh/src/commands/info.rs
@@ -196,16 +196,31 @@ pub async fn handle_info(
         }
 
         InfoCommands::Position { wait, request_all } => {
+            // First, send position requests if requested
+            if request_all {
+                println!("Requesting positions from all nodes...");
+                rmesh_core::position::send_position_requests(&mut connection).await?;
+            }
+
+            // Then collect positions based on wait flag
             let positions = if let Some(wait_seconds) = wait {
-                // Wait for position broadcasts
-                println!("Waiting {wait_seconds} seconds for position broadcasts...");
+                // Wait for position broadcasts/responses
+                if request_all {
+                    println!(
+                        "Waiting {wait_seconds} seconds for position responses and broadcasts..."
+                    );
+                } else {
+                    println!("Waiting {wait_seconds} seconds for position broadcasts...");
+                }
                 rmesh_core::position::collect_positions(&mut connection, wait_seconds).await?
             } else if request_all {
-                // Request positions from all known nodes
-                println!("Requesting positions from all nodes...");
-                rmesh_core::position::request_all_positions(&mut connection).await?
+                // Just requested positions, wait default 10 seconds for responses
+                println!("Waiting for position responses...");
+                tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                let state = connection.get_device_state().await;
+                state.positions
             } else {
-                // Get current position data from device state
+                // No flags: Get current position data from device state
                 let state = connection.get_device_state().await;
                 state.positions
             };

--- a/rmesh/src/commands/info.rs
+++ b/rmesh/src/commands/info.rs
@@ -198,7 +198,7 @@ pub async fn handle_info(
         InfoCommands::Position { wait, request_all } => {
             // First, send position requests if requested
             if request_all {
-                println!("Requesting positions from all nodes...");
+                eprintln!("Requesting positions from all nodes...");
                 rmesh_core::position::send_position_requests(&mut connection).await?;
             }
 
@@ -206,16 +206,16 @@ pub async fn handle_info(
             let positions = if let Some(wait_seconds) = wait {
                 // Wait for position broadcasts/responses
                 if request_all {
-                    println!(
+                    eprintln!(
                         "Waiting {wait_seconds} seconds for position responses and broadcasts..."
                     );
                 } else {
-                    println!("Waiting {wait_seconds} seconds for position broadcasts...");
+                    eprintln!("Waiting {wait_seconds} seconds for position broadcasts...");
                 }
                 rmesh_core::position::collect_positions(&mut connection, wait_seconds).await?
             } else if request_all {
                 // Just requested positions, wait default 10 seconds for responses
-                println!("Waiting for position responses...");
+                eprintln!("Waiting for position responses...");
                 tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
                 let state = connection.get_device_state().await;
                 state.positions


### PR DESCRIPTION
## Summary
Fixes the issue where `--wait` and `--request-all` flags couldn't be used together effectively. Now they work in combination to provide comprehensive position data collection.

## Problem
When using both `--wait` and `--request-all` flags together, only the wait flag was being processed, and the position requests weren't being sent. This made it impossible to actively request positions and then wait for responses.

## Solution
- Added `send_position_requests()` function that sends position requests without waiting
- Refactored the CLI logic to handle both flags in combination
- When both flags are used together:
  1. First sends position requests to all known nodes
  2. Then waits for the specified duration to collect both responses and any additional broadcasts

## Implementation
- Created `send_position_requests()` to separate request sending from waiting
- Updated `request_all_positions()` to use the new function
- Modified CLI handler to process both flags sequentially

## Usage
```bash
# Use both flags together for comprehensive position collection
rmesh info position --wait 60 --request-all --json

# This will:
# 1. Send position requests to all known nodes
# 2. Wait 60 seconds collecting both responses and broadcasts
```

## Test Plan
- [x] Tested with `--wait` flag alone
- [x] Tested with `--request-all` flag alone  
- [x] Tested with both flags together
- [x] Verified JSON output works correctly
- [x] All tests pass