### PR TITLE
fix: show ISO datetime format for Last Heard in nodes table

### DIFF
--- a/rmesh-core/src/connection/manager.rs
+++ b/rmesh-core/src/connection/manager.rs
@@ -496,6 +496,10 @@ async fn process_from_radio_packet(
         meshtastic::protobufs::from_radio::PayloadVariant::NodeInfo(node_info) => {
             let mut state = device_state.lock().await;
             let user = node_info.user.clone().unwrap_or_default();
+            let last_heard = node_info.last_heard as u64;
+            let last_heard_iso =
+                chrono::DateTime::from_timestamp(last_heard as i64, 0).map(|dt| dt.to_rfc3339());
+
             state.update_node(
                 node_info.num,
                 NodeInfo {
@@ -507,7 +511,8 @@ async fn process_from_radio_packet(
                         short_name: user.short_name.clone(),
                         hw_model: Some(format!("{model:?}", model = user.hw_model())),
                     },
-                    last_heard: Some(node_info.last_heard as u64),
+                    last_heard: Some(last_heard),
+                    last_heard_iso,
                     snr: Some(node_info.snr),
                     rssi: Some(0), // NodeInfo doesn't have RSSI
                 },

--- a/rmesh-core/src/state.rs
+++ b/rmesh-core/src/state.rs
@@ -26,6 +26,7 @@ pub struct NodeInfo {
     pub num: u32,
     pub user: User,
     pub last_heard: Option<u64>,
+    pub last_heard_iso: Option<String>,
     pub snr: Option<f32>,
     pub rssi: Option<i32>,
 }

--- a/rmesh-core/src/tests.rs
+++ b/rmesh-core/src/tests.rs
@@ -28,6 +28,8 @@ mod state_tests {
                 hw_model: Some("T-Beam".to_string()),
             },
             last_heard: Some(1234567890),
+            last_heard_iso: chrono::DateTime::from_timestamp(1234567890, 0)
+                .map(|dt| dt.to_rfc3339()),
             snr: Some(5.5),
             rssi: Some(-70),
         };
@@ -118,6 +120,7 @@ mod state_tests {
                 hw_model: None,
             },
             last_heard: None,
+            last_heard_iso: None,
             snr: None,
             rssi: None,
         };

--- a/rmesh/src/commands/info.rs
+++ b/rmesh/src/commands/info.rs
@@ -146,7 +146,10 @@ pub async fn handle_info(
                             ),
                             Cell::new(
                                 node.last_heard
-                                    .map(|h| h.to_string())
+                                    .and_then(|timestamp| {
+                                        chrono::DateTime::from_timestamp(timestamp as i64, 0)
+                                            .map(|dt| dt.to_rfc3339())
+                                    })
                                     .unwrap_or_else(|| "Never".to_string()),
                             ),
                         ]);


### PR DESCRIPTION
## Summary
Converts Unix timestamps to ISO 8601 datetime format in the nodes table for better readability.

## Before
```
│ 7e9bb193 ┆ 2124132755 ┆ Solar b193      ┆ 2.0  ┆ 1756605806 │
│ 608c440e ┆ 1619805198 ┆ Solar 440e      ┆ 9.8  ┆ 1756605936 │
```

## After
```
│ 7e9bb193 ┆ 2124132755 ┆ Solar b193      ┆ 2.0  ┆ 2025-08-31T02:03:26+00:00 │
│ 608c440e ┆ 1619805198 ┆ Solar 440e      ┆ 9.8  ┆ 2025-08-31T02:05:36+00:00 │
```

## Changes
- Uses `chrono::DateTime::from_timestamp()` to convert Unix timestamps
- Formats as RFC3339 (ISO 8601) for consistency
- Shows "Never" for nodes that haven't been heard from

## Test Plan
- [x] Tested with `rmesh info nodes` command
- [x] Verified datetime format displays correctly
- [x] Confirmed "Never" shows for nodes without last_heard
- [x] JSON output remains unchanged (still uses Unix timestamps)