### PR TITLE
feat: add wait and request flags to metrics command

### DIFF
--- a/rmesh-core/src/telemetry.rs
+++ b/rmesh-core/src/telemetry.rs
@@ -90,13 +90,13 @@ pub async fn collect_telemetry(
         let state = connection.get_device_state().await;
 
         // Check for new or updated telemetry
-        if let Some(telemetry) = state.telemetry.get(&local_node_num) {
-            if let Some(metrics) = &telemetry.device_metrics {
-                // Check if this is newer than what we started with
-                if initial_time.is_none() || telemetry.time > initial_time.unwrap() {
-                    debug!("Received telemetry update from local device");
-                    return Ok(Some(metrics.clone()));
-                }
+        if let Some(telemetry) = state.telemetry.get(&local_node_num)
+            && let Some(metrics) = &telemetry.device_metrics
+        {
+            // Check if this is newer than what we started with
+            if initial_time.is_none() || telemetry.time > initial_time.unwrap() {
+                debug!("Received telemetry update from local device");
+                return Ok(Some(metrics.clone()));
             }
         }
 

--- a/rmesh-core/src/telemetry.rs
+++ b/rmesh-core/src/telemetry.rs
@@ -1,14 +1,124 @@
 use crate::connection::ConnectionManager;
+use crate::state::DeviceMetrics;
 use anyhow::Result;
+use meshtastic::Message;
+use meshtastic::packet::PacketDestination;
+use meshtastic::protobufs;
+use meshtastic::types::EncodedMeshPacketData;
 use serde::Serialize;
+use tokio::time::{Duration, sleep};
+use tracing::{debug, info};
 
-/// Request telemetry from a node
+/// Request telemetry from the local device
+pub async fn request_device_telemetry(connection: &mut ConnectionManager) -> Result<()> {
+    // Get local node number
+    let state = connection.get_device_state().await;
+    let local_node_num = match &state.my_node_info {
+        Some(info) => info.node_num,
+        None => {
+            debug!("No local node information available");
+            return Ok(());
+        }
+    };
+
+    // Create an empty telemetry packet to request telemetry
+    let telemetry = protobufs::Telemetry::default();
+
+    // Create a simple packet router
+    let mut packet_router = SimplePacketRouter;
+
+    // Get API and send telemetry request with wantResponse flag
+    let api = connection.get_api()?;
+
+    // Encode telemetry to bytes
+    let byte_data: EncodedMeshPacketData = telemetry.encode_to_vec().into();
+
+    // Send mesh packet to self with want_response set to true
+    api.send_mesh_packet(
+        &mut packet_router,
+        byte_data,
+        protobufs::PortNum::TelemetryApp,
+        PacketDestination::Node(local_node_num.into()),
+        0.into(), // primary channel
+        false,    // want_ack
+        true,     // want_response - request telemetry
+        false,    // echo_response
+        None,     // reply_id
+        None,     // emoji
+    )
+    .await?;
+
+    info!("Sent telemetry request to local device");
+    Ok(())
+}
+
+/// Collect telemetry data for a specified duration
+pub async fn collect_telemetry(
+    connection: &mut ConnectionManager,
+    wait_seconds: u64,
+) -> Result<Option<DeviceMetrics>> {
+    info!("Collecting telemetry broadcasts for {wait_seconds} seconds...");
+
+    // Get local node number
+    let state = connection.get_device_state().await;
+    let local_node_num = match &state.my_node_info {
+        Some(info) => info.node_num,
+        None => {
+            debug!("No local node information available");
+            return Ok(None);
+        }
+    };
+
+    // Record initial state
+    let initial_metrics = state
+        .telemetry
+        .get(&local_node_num)
+        .and_then(|t| t.device_metrics.clone());
+    let initial_time = initial_metrics.as_ref().map(|_| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    });
+
+    // Poll for new telemetry during the wait period
+    let start_time = std::time::Instant::now();
+    let timeout_duration = Duration::from_secs(wait_seconds);
+
+    while start_time.elapsed() < timeout_duration {
+        // Get current state
+        let state = connection.get_device_state().await;
+
+        // Check for new or updated telemetry
+        if let Some(telemetry) = state.telemetry.get(&local_node_num) {
+            if let Some(metrics) = &telemetry.device_metrics {
+                // Check if this is newer than what we started with
+                if initial_time.is_none() || telemetry.time > initial_time.unwrap() {
+                    debug!("Received telemetry update from local device");
+                    return Ok(Some(metrics.clone()));
+                }
+            }
+        }
+
+        // Wait a bit before checking again
+        sleep(Duration::from_millis(250)).await;
+    }
+
+    // Return whatever we have (could be initial metrics or nothing)
+    let final_state = connection.get_device_state().await;
+    Ok(final_state
+        .telemetry
+        .get(&local_node_num)
+        .and_then(|t| t.device_metrics.clone()))
+}
+
+/// Request telemetry from a node (legacy function, kept for compatibility)
 pub async fn request_telemetry(
     _connection: &mut ConnectionManager,
     _telemetry_type: TelemetryType,
     _node_id: Option<u32>,
 ) -> Result<()> {
-    // TODO: Implement telemetry request
+    // TODO: Implement telemetry request for specific types
     Ok(())
 }
 
@@ -17,4 +127,47 @@ pub enum TelemetryType {
     Battery,
     Environment,
     Device,
+}
+
+// Simple packet router that ignores all packets
+struct SimplePacketRouter;
+
+use meshtastic::types::NodeId;
+
+impl meshtastic::packet::PacketRouter<(), std::convert::Infallible> for SimplePacketRouter {
+    fn handle_packet_from_radio(
+        &mut self,
+        packet: protobufs::FromRadio,
+    ) -> Result<(), std::convert::Infallible> {
+        if let Some(variant) = &packet.payload_variant {
+            debug!(
+                "SimplePacketRouter: Ignoring FromRadio packet (variant: {variant:?})",
+                variant = std::mem::discriminant(variant)
+            );
+        } else {
+            debug!("SimplePacketRouter: Ignoring empty FromRadio packet");
+        }
+        Ok(())
+    }
+
+    fn handle_mesh_packet(
+        &mut self,
+        packet: protobufs::MeshPacket,
+    ) -> Result<(), std::convert::Infallible> {
+        let portnum = packet.payload_variant.as_ref().and_then(|p| match p {
+            protobufs::mesh_packet::PayloadVariant::Decoded(d) => Some(d.portnum()),
+            _ => None,
+        });
+
+        debug!(
+            "SimplePacketRouter: Ignoring MeshPacket (from: {from:08x}, to: {to:08x}, portnum: {portnum:?})",
+            from = packet.from,
+            to = packet.to
+        );
+        Ok(())
+    }
+
+    fn source_node_id(&self) -> NodeId {
+        0u32.into() // Default node ID for simple router
+    }
 }

--- a/rmesh/src/cli.rs
+++ b/rmesh/src/cli.rs
@@ -117,7 +117,15 @@ pub enum InfoCommands {
         request_all: bool,
     },
     /// Display device metrics
-    Metrics,
+    Metrics {
+        /// Wait for telemetry broadcasts (in seconds)
+        #[arg(short = 'w', long)]
+        wait: Option<u64>,
+
+        /// Request telemetry from the device
+        #[arg(short = 'r', long)]
+        request: bool,
+    },
     /// Display telemetry data
     Telemetry,
 }

--- a/rmesh/src/commands/info.rs
+++ b/rmesh/src/commands/info.rs
@@ -331,7 +331,7 @@ pub async fn handle_info(
                             Cell::new("Uptime"),
                             Cell::new(
                                 m.uptime_seconds
-                                    .map(|s| format_uptime(s))
+                                    .map(format_uptime)
                                     .unwrap_or_else(|| "N/A".to_string()),
                             ),
                         ]);


### PR DESCRIPTION
## Summary
Adds `--wait` and `--request` flags to the `rmesh info metrics` command for more reliable telemetry collection, similar to the position command implementation.

## Problem
Previously, the metrics command would only show telemetry data that was already cached in memory. Since telemetry is sent periodically (often with long intervals), users would frequently see "No metrics data available" even though their device was working properly.

## Solution
This PR introduces two new flags:

1. **`--wait <seconds>`**: Keeps the connection open and collects telemetry broadcasts for the specified duration
2. **`--request`**: Actively requests telemetry from the device (sends a telemetry packet with `wantResponse=true`)

The flags can be combined to request telemetry and then wait for the response.

## Implementation Details
- Added `collect_telemetry()` function to poll for telemetry updates during wait period
- Added `request_device_telemetry()` function to send telemetry request to local device
- Updated CLI to accept the new flags
- Modified metrics command handler to support both flags individually and in combination

## Usage Examples
```bash
# Wait 30 seconds for telemetry broadcasts
rmesh info metrics --wait 30

# Request telemetry from device (waits 10s by default)
rmesh info metrics --request

# Request and wait for specific duration
rmesh info metrics --request --wait 60

# JSON output with wait
rmesh info metrics --wait 30 --json
```

## Also Includes
- Implementation of device metrics display (battery, voltage, uptime, etc.)
- Human-readable uptime formatting (e.g., "2d 3h 45m")
- Support for both table and JSON output formats

## Test Plan
- [x] Basic metrics command works
- [x] `--wait` flag properly waits for specified duration
- [x] `--request` flag compiles and includes proper telemetry request logic
- [x] Combined flags work together
- [x] JSON output format works correctly
- [x] All tests pass
- [x] Clippy warnings resolved