### PR TITLE
feat: implement admin authentication for config and channel operations

### DIFF
--- a/rmesh-core/src/channel.rs
+++ b/rmesh-core/src/channel.rs
@@ -29,6 +29,12 @@ pub async fn add_channel(
     name: &str,
     psk: Option<&str>,
 ) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
 
     // Create channel settings
@@ -51,7 +57,7 @@ pub async fn add_channel(
                 role: protobufs::channel::Role::Primary as i32,
             },
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet
@@ -88,6 +94,12 @@ pub async fn add_channel(
 
 /// Delete a channel
 pub async fn delete_channel(connection: &mut ConnectionManager, index: u32) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
 
     // Create admin message for channel delete
@@ -95,7 +107,7 @@ pub async fn delete_channel(connection: &mut ConnectionManager, index: u32) -> R
         payload_variant: Some(protobufs::admin_message::PayloadVariant::RemoveByNodenum(
             index,
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet
@@ -137,6 +149,12 @@ pub async fn set_channel(
     name: Option<&str>,
     psk: Option<&str>,
 ) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
 
     // Create channel settings
@@ -159,7 +177,7 @@ pub async fn set_channel(
                 role: protobufs::channel::Role::Primary as i32,
             },
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet

--- a/rmesh-core/src/config.rs
+++ b/rmesh-core/src/config.rs
@@ -8,6 +8,9 @@ pub async fn get_config_value(
     connection: &mut ConnectionManager,
     key: &str,
 ) -> Result<serde_json::Value> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
     // Parse the key
     let parts: Vec<&str> = key.split('.').collect();
     ensure!(
@@ -17,6 +20,9 @@ pub async fn get_config_value(
 
     let category = parts[0];
     let field = parts[1];
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
 
     // Send config request
     let api = connection.get_api()?;
@@ -33,12 +39,12 @@ pub async fn get_config_value(
         _ => bail!("Unknown config category: {category}"),
     };
 
-    // Create admin message for config request
+    // Create admin message for config request with session key
     let admin_msg = protobufs::AdminMessage {
         payload_variant: Some(protobufs::admin_message::PayloadVariant::GetConfigRequest(
             config_type as i32,
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet
@@ -146,6 +152,12 @@ pub async fn set_config_value(
     key: &str,
     value: &str,
 ) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
 
     let parts: Vec<&str> = key.split('.').collect();
@@ -176,7 +188,7 @@ pub async fn set_config_value(
                                 )),
                             },
                         )),
-                        session_passkey: Vec::new(),
+                        session_passkey: session_key.clone(),
                     }
                 }
                 _ => bail!("Unknown lora field: {field}"),
@@ -199,7 +211,7 @@ pub async fn set_config_value(
                                 )),
                             },
                         )),
-                        session_passkey: Vec::new(),
+                        session_passkey: session_key.clone(),
                     }
                 }
                 _ => bail!("Unknown device field: {field}"),

--- a/rmesh-core/src/device.rs
+++ b/rmesh-core/src/device.rs
@@ -11,6 +11,12 @@ pub async fn reboot_device(
     connection: &mut ConnectionManager,
     delay_seconds: Option<i32>,
 ) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
     let delay = delay_seconds.unwrap_or(5);
 
@@ -19,7 +25,7 @@ pub async fn reboot_device(
         payload_variant: Some(protobufs::admin_message::PayloadVariant::RebootSeconds(
             delay,
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet
@@ -59,12 +65,18 @@ pub async fn reboot_device(
 /// # Warning
 /// This will erase all device settings and cannot be undone!
 pub async fn factory_reset_device(connection: &mut ConnectionManager) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
 
     // Create admin message for factory reset
     let admin_msg = protobufs::AdminMessage {
         payload_variant: Some(protobufs::admin_message::PayloadVariant::FactoryResetDevice(1)),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet
@@ -108,6 +120,12 @@ pub async fn shutdown_device(
     connection: &mut ConnectionManager,
     delay_seconds: Option<i32>,
 ) -> Result<()> {
+    // Ensure we have a session key for admin operations
+    connection.ensure_session_key().await?;
+
+    // Get the session key
+    let session_key = connection.get_session_key().await.unwrap_or_default();
+
     let api = connection.get_api()?;
     let delay = delay_seconds.unwrap_or(5);
 
@@ -116,7 +134,7 @@ pub async fn shutdown_device(
         payload_variant: Some(protobufs::admin_message::PayloadVariant::ShutdownSeconds(
             delay,
         )),
-        session_passkey: Vec::new(),
+        session_passkey: session_key,
     };
 
     // Create mesh packet


### PR DESCRIPTION
## Summary
- Implements session key-based authentication for all admin operations
- Adds session passkey management to ConnectionManager
- Ensures all config, channel, and device operations use proper authentication

## Changes
- Added  field to ConnectionManager for session key storage
- Implemented  method to request and wait for session key
- Added session key lifecycle methods (get, set, clear)
- Updated all admin operations to include session key in AdminMessage
- Modified packet processing to extract and store session keys from admin responses
- Updated config get/set, channel add/delete/set, and device operations with authentication

## Test Plan
- [x] Code builds successfully without warnings
- [x] All existing tests pass
- [x] Clippy passes without warnings
- [x] Code is properly formatted

## Breaking Changes
None - this adds authentication support transparently

This completes Phase 1 of the admin authentication implementation, enabling proper authenticated access to all admin operations.