### PR TITLE
fix: replace unmaintained atty and number_prefix dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,17 +88,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,15 +304,14 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
  "unicode-width",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,15 +611,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,14 +666,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
- "number_prefix",
  "portable-atomic",
  "unicode-width",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -971,12 +950,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "objc-sys"
@@ -1274,7 +1247,6 @@ name = "rmesh-test"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "chrono",
  "clap",
  "colored",
@@ -1706,6 +1678,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ log = "0.4"
 # CLI dependencies
 clap = { version = "4.5", features = ["derive", "env", "cargo", "color"] }
 colored = "2.1"
-indicatif = "0.17"
+indicatif = "0.18"
 comfy-table = "7.1"
 
 # Utilities

--- a/rmesh-test/Cargo.toml
+++ b/rmesh-test/Cargo.toml
@@ -32,4 +32,3 @@ chrono = { workspace = true }
 
 # Additional dependencies for testing
 uuid = { version = "1.11", features = ["v4"] }
-atty = "0.2"

--- a/rmesh-test/src/main.rs
+++ b/rmesh-test/src/main.rs
@@ -5,6 +5,7 @@ mod tests;
 use anyhow::Result;
 use clap::{Parser, ValueEnum};
 use colored::*;
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use tracing_subscriber::EnvFilter;
 
@@ -72,7 +73,7 @@ async fn main() -> Result<()> {
     };
 
     // Check if we're connected to a TTY
-    let is_tty = atty::is(atty::Stream::Stdout);
+    let is_tty = std::io::stdout().is_terminal();
     let non_interactive = args.non_interactive || !is_tty;
 
     tracing_subscriber::fmt()


### PR DESCRIPTION
## Summary
- Replace `atty` with `std::io::IsTerminal` (stable since Rust 1.70)
- Upgrade `indicatif` 0.17 → 0.18, which replaces unmaintained `number_prefix` with `unit-prefix`

## Advisories resolved
- RUSTSEC-2024-0375 (`atty` unmaintained)
- RUSTSEC-2021-0145 (`atty` potential unaligned read)
- RUSTSEC-2025-0119 (`number_prefix` unmaintained)

## Verification
`cargo audit` returns zero advisories after this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `indicatif` dependency to version 0.18
  * Refactored terminal detection to use Rust standard library
  * Updated test dependencies

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/douglaz/rmesh/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->